### PR TITLE
Allow use with node.js >= 0.6  (closes #36)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "expresso": "~0.9.0"
     },
     "engines": {
-        "node": "~0.6.x"
+        "node": ">= 0.6.0"
     },
     "scripts": {
         "pretest": "which expresso || npm install --dev",


### PR DESCRIPTION
'npm test' succeeded with node-0.8.0, so I'm guessing it will also work with 0.7.x (in addition to the already-required 0.6)
