### PR TITLE
Drop MapnikSource from cache on .close()

### DIFF
--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -23,6 +23,7 @@ require('util').inherits(MapnikSource, require('events').EventEmitter);
 function MapnikSource(uri, callback) {
     uri = this._normalizeURI(uri);
     var key = url.format(uri);
+    this.cache_key = key;
 
     if (uri.protocol && uri.protocol !== 'mapnik:') {
         throw new Error('Only the mapnik protocol is supported');
@@ -145,6 +146,7 @@ MapnikSource.prototype.close = function(callback) {
 };
 
 MapnikSource.prototype._close = function() {
+    delete cache[this.cache_key];
     if (this._tileCache) this._tileCache.clear();
     // Note: this doesn't clear timeouts in node-pool.
     // See https://github.com/coopernurse/node-pool/issues/17


### PR DESCRIPTION
The object is unusable after calling .close(), anyway.
Closes #47
