### PR TITLE
Use solidcache local to the MapnikSource instance

### DIFF
--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -51,6 +51,8 @@ function MapnikSource(uri, callback) {
             callback(null, source);
         }
     }
+    // cache used to skip encoding of solid images
+    this.solidCache = {};
     return undefined;
 }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -4,7 +4,6 @@ var Step = require('step');
 var mime = require('mime')
 
 var MapnikSource = require('./mapnik_backend');
-var solidCache = {};
 
 var EARTH_RADIUS = 6378137;
 var EARTH_DIAMETER = EARTH_RADIUS * 2;
@@ -49,7 +48,7 @@ function calculateMetatile(options) {
 }
 
 exports['sliceMetatile'] = sliceMetatile;
-function sliceMetatile(image, options, meta, callback) {
+function sliceMetatile(source, image, options, meta, callback) {
     var tiles = {};
 
     Step(function() {
@@ -57,7 +56,8 @@ function sliceMetatile(image, options, meta, callback) {
         meta.tiles.forEach(function(c) {
             var next = group();
             var key = [options.format, c[0], c[1], c[2]].join(',');
-            getImage(image,
+            getImage(source,
+                     image,
                      options,
                      (c[1] - meta.x) * options.tileSize,
                      (c[2] - meta.y) * options.tileSize,
@@ -76,17 +76,17 @@ function sliceMetatile(image, options, meta, callback) {
 }
 
 exports['encodeSingleTile'] = encodeSingleTile;
-function encodeSingleTile(image, options, meta, callback) {
+function encodeSingleTile(source, image, options, meta, callback) {
     var tiles = {};
     var key = [options.format, options.z, options.x, options.y].join(',');
-    getImage(image, options, 0, 0, function(err, image) {
+    getImage(source, image, options, 0, 0, function(err, image) {
         if (err) return callback(err);
         tiles[key] = { image: image, headers: options.headers };
         callback(null, tiles);
     });
 }
 
-function getImage(image, options, x, y, callback) {
+function getImage(source, image, options, x, y, callback) {
     var view = image.view(x, y, options.tileSize, options.tileSize);
     view.isSolid(function(err, solid, pixel) {
         if (err) return callback(err);
@@ -101,7 +101,7 @@ function getImage(image, options, x, y, callback) {
                 var r = pixel & 0xff;
                 var g = (pixel>>>8) & 0xff;
                 var b = (pixel>>>16) & 0xff;
-                pixel_key = options.format + '-' + r +','+ g + ',' + b + ',' + a;
+                pixel_key = r +','+ g + ',' + b + ',' + a;
             }
         }
         // Add stats.
@@ -109,7 +109,7 @@ function getImage(image, options, x, y, callback) {
         if (solid !== false) options.source._stats.solid++;
         if (solid !== false && image.painted()) options.source._stats.solidPainted++;
         // If solid and image buffer is cached skip image encoding.
-        if (solid && solidCache[pixel_key]) return callback(null, solidCache[pixel_key]);
+        if (solid && source.solidCache[pixel_key]) return callback(null, source.solidCache[pixel_key]);
         // Note: the second parameter is needed for grid encoding.
         options.source._stats.encoded++;
         try {
@@ -123,7 +123,7 @@ function getImage(image, options, x, y, callback) {
                     // Fix is to propagate a third parameter through callbacks all
                     // the way back to tilelive source #getGrid.
                     buffer.solid = pixel_key;
-                    solidCache[pixel_key] = buffer;
+                    source.solidCache[pixel_key] = buffer;
                 }
                 return callback(null, buffer);
             });
@@ -189,9 +189,9 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
                         });
                         if (err) return callback(err);
                         if (meta.tiles.length > 1) {
-                            sliceMetatile(image, options, meta, callback);
+                            sliceMetatile(source, image, options, meta, callback);
                         } else {
-                            encodeSingleTile(image, options, meta, callback);
+                            encodeSingleTile(source, image, options, meta, callback);
                         }
                     });
                 } catch(err) {


### PR DESCRIPTION
This change moves the `solidCache` to a member of the `MapnikSource` instead of being global.

Benefits:
- Keeps performance boost from caching solid tiles to avoid encoding overhead - 
- Avoids needing to key the cache on the format since the format should be constant for a given `MapnikSource` instance
- Works around stale global cache data for grids that are only keyed on their buffer information and not their attributes - to solve #61/#55 then new `MapnikSource` objects need to be created in interactivity settings are changed.
- Avoid having to move on #63
