### PR TITLE
Fix comment about use of internal_cache option

### DIFF
--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -27,7 +27,7 @@ function MapnikSource(uri, callback) {
         throw new Error('Only the mapnik protocol is supported');
     }
     // by default we use an internal self-caching mechanism but
-    // calling applications can pass `internal_cache:true` to disable
+    // calling applications can pass `internal_cache:false` to disable
     // TODO - consider removing completely once https://github.com/mapbox/tilemill/issues/1893
     // is in place and a solid reference implementation of external caching
     if (uri.query.internal_cache === false) {


### PR DESCRIPTION
The comment above the "internal_cache" option says you have to set to "true" to disable, while instead you have to set to "false" to disable it...
