### PR TITLE
Coerce scale to a Number to make Mapnik happy

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -162,7 +162,7 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
         var image = new mapnik.Image(meta.width, meta.height);
     }
 
-    options.scale = source._uri.query.scale;
+    options.scale = +source._uri.query.scale;
 
     // Add reference to the source allowing debug/stat reporting to be compiled.
     options.source = source;


### PR DESCRIPTION
Without this, Mapnik emits `TypeError: optional arg 'scale' must be a number`.
