### PR TITLE
Expose mapnik binding

### DIFF
--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -61,6 +61,8 @@ function MapnikSource(uri, callback) {
     return undefined;
 }
 
+MapnikSource.mapnik = mapnik;
+
 MapnikSource.prototype.toJSON = function() {
     return url.format(this._uri);
 };

--- a/test/test.mapnik.js
+++ b/test/test.mapnik.js
@@ -1,0 +1,10 @@
+var assert = require('assert');
+var mapnik_backend = require('..');
+var mapnik = require("mapnik");
+
+describe('.mapnik', function() {
+
+    it('exposes the mapnik binding', function() {
+        assert.equal(mapnik, mapnik_backend.mapnik);
+    });
+});


### PR DESCRIPTION
(Includes changes from #68)

node-mapnik removed default font auto-registration in 1.1.2.  tilelive-mapnik doesn't register fonts (perhaps it should?), so I exposed the mapnik binding as `.mapnik` so that dependents can do it themselves (and otherwise manipulate mapnik settings directly).
