### PR TITLE
Check that uri.pathname is not undefined before using path to resolve it

### DIFF
--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -74,7 +74,7 @@ MapnikSource.prototype._normalizeURI = function(uri) {
         delete uri.hostname;
         delete uri.host;
     }
-    uri.pathname = path.resolve(uri.pathname);
+    if (typeof uri.pathname !== "undefined") uri.pathname = path.resolve(uri.pathname);
     uri.query = uri.query || {};
     if (typeof uri.query === 'string') uri.query = qs.parse(uri.query);
     if (typeof uri.query.internal_cache === "undefined") uri.query.internal_cache = true;


### PR DESCRIPTION
See bottom of http://techblog.realestate.com.au/setup-cartodb-dev-environment-on-mac-os-x/. Also necessary for standalone Windshaft-based app.
