### PR TITLE
Correct UTF grid content type

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -145,7 +145,7 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
         options.layer = source._info.interactivity_layer;
         options.fields = source._info.interactivity_fields;
         options.resolution = source._uri.query.resolution;
-        options.headers = { 'Content-Type': 'text/javascript; charset=utf-8' };
+        options.headers = { 'Content-Type': 'application/json' };
         var image = new mapnik.Grid(meta.width, meta.height);
     } else {
         // NOTE: formats use mapnik syntax like `png8:m=h` or `jpeg80`

--- a/test/grid.test.js
+++ b/test/grid.test.js
@@ -51,7 +51,7 @@ describe('Render ', function() {
                     if (err) throw err;
                     assert.deepEqual(info, JSON.parse(fs.readFileSync('test/fixture/grids/' + key + '.grid.json', 'utf8')));
                     assert.deepEqual(headers, {
-                        "Content-Type": "text/javascript; charset=utf-8"
+                        "Content-Type": "application/json"
                     });
                     ++count;
                     if (count == array.length) {


### PR DESCRIPTION
UTF grids should be served up as JSON.  This matches [tilelive-vector's behavior](https://github.com/mapbox/tilelive-vector/blob/4979d339b4324c6cea392ba184aa26350f0fbeb4/index.js#L135-L136).
