### PR TITLE
Add ?poolSize, falling back to UV_THREADPOOL_SIZE

### DIFF
--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -229,9 +229,7 @@ MapnikSource.prototype._createPool = function(xml, callback) {
         destroy: function(map) {
             delete map;
         },
-        // @TODO: need a smarter way to scale this. More
-        // maps in pool seems better for PostGIS.
-        max: require('os').cpus().length
+        max: source._uri.query.poolSize || process.env.UV_THREADPOOL_SIZE || require('os').cpus().length
     });
     callback(null);
 };


### PR DESCRIPTION
...further falling back to the number of cores reported.

Without this in place, setting `UV_THREADPOOL_SIZE` to anything larger than the number of cores reported is ineffectual.  For most cases, matching the pool size to libuv's threadpool size makes sense, as the ratio of maps to render calls is typically 1:1.  When it's not (if additional map instances (potentially through multiple `tilelive-mapnik` instances), `poolSize` can be provided as an argument when loading.
