### PR TITLE
Pass bufferSize param as a rendering option

### DIFF
--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -275,6 +275,7 @@ MapnikSource.prototype._createMetatileCache = function() {
         var keys = source._renderMetatile({
             metatile: source._uri.query.metatile,
             tileSize: source._uri.query.tileSize,
+            buffer_size: source.bufferSize,
             format: coords[0],
             z: +coords[1],
             x: +coords[2],

--- a/lib/render.js
+++ b/lib/render.js
@@ -179,7 +179,6 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
                 options.y = meta.y;
                 map.resize(meta.width, meta.height);
                 map.extent = meta.bbox;
-                // todo - handle per tile bufferSize: https://github.com/mapnik/node-mapnik/issues/175
                 try {
                     source._stats.render++;
                     map.render(image, options, function(err, image) {


### PR DESCRIPTION
After https://github.com/mapnik/node-mapnik/commit/5b823e0a52010e29a5d0c44adc590f9a28f217be, `tilelive-mapnik` lost the ability to render with a buffer.  This re-adds that ability, but instead of pulling from the `Map` object, it grabs the buffer size from `tilelive-mapnik`'s options.

(Probably warrants a new release to match mapnik@1.4.12+)

Fixes mapnik/mapnik#2378
Re: mapnik/node-mapnik#175
