### PR TITLE
Serialize keys using JSON.serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # tilelive-mapnik changelog
 
+## vNext
+
+* Improved cache key generation
+
 ## 0.6.11
 
 * Support for node-mapnik >= 1.4.12

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -19,7 +19,7 @@ exports = module.exports = MapnikSource;
 require('util').inherits(MapnikSource, require('events').EventEmitter);
 function MapnikSource(uri, callback) {
     uri = this._normalizeURI(uri);
-    var key = url.format(uri);
+    var key = JSON.stringify(uri);
 
     if (uri.protocol && uri.protocol !== 'mapnik:') {
         throw new Error('Only the mapnik protocol is supported');


### PR DESCRIPTION
`url.format()` is a poor choice for serialization when non-standard properties are tacked on, as they get dropped (and when `uri.query` properties aren't also included in `uri.path`).
