### PR TITLE
Fix for node.js 6

### DIFF
--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -205,7 +205,7 @@ MapnikSource.registerProtocols = function(tilelive) {
 // an error as its first argument.
 MapnikSource.prototype._loadXML = function(callback) {
     var source = this;
-    this._base = path.resolve(path.dirname(this._uri.pathname));
+    this._base = path.resolve(path.dirname(this._uri.pathname || "."));
 
     // This is a string-based map file. Pass it on literally.
     if (this._uri.xml) return callback(null, this._uri.xml);


### PR DESCRIPTION
In Node <= 4, `path.dirname()` returned ".", but in Node 6+, it throws an exception. This makes the uri pathname optional and keeps backward compatibitlity.