### PR TITLE
Mapnik 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,8 @@
   "dependencies": {
     "step": "~0.0.5",
     "generic-pool": "~2.4.0",
-    "mapnik": ">=3.2.0 && <4.0.0",
-    "mime": "~1.3.4",
-    "sphericalmercator": "~1.0.4"
+    "mapnik": "~3.6.0",
+    "mime": "~1.3.4"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
Updated package to use mapnik 3.6.0, removed unrequired sphericalmercator package.
/cc @mapsam @GretaCB @springmeyer 