### PR TITLE
add clearCache function

### DIFF
--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -366,5 +366,10 @@ MapnikSource.prototype.getInfo = function(callback) {
     else callback(new Error('Info is unavailable'));
 };
 
+MapnikSource.prototype.clearCache = function(){
+	cache = {};
+	this._cache = cache;
+};
+
 // Add other functions.
 require('./render');


### PR DESCRIPTION
I find that when the Mapnik XML content changed or the data of the Mapnik XML changed, the rendering result of  the tilelive-mapnik does not changed, because tilelive-mapnik still uses the cache if the Mapnik XML filename does not changed( I notice that tilelive mapnik store the cache throw uri). this function helps to clear the cache dynamically, if the style has been changed, run it, tilelive-mapnik will generate the newest rendering result .