### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "step": "~0.0.5",
     "generic-pool": "~2.4.0",
-    "mapnik": "~3.7.0",
+    "mapnik": "~4.0.1",
     "mime": "~1.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
updated mapnik to v4.0.1

due to that node-mapnik is incompatible with node >= v10. 
See also: https://github.com/mapnik/node-mapnik/issues/895#issuecomment-413554215