### PR TITLE
CLOUDPLAT-3162: add npm OIDC publish workflow (tilelive-mapnik)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,15 @@
+name: NPM release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  npm-release:
+    uses: mapbox/gha-public/.github/workflows/workflow-npm-oidc-publish.yml@main
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      create-github-release: true
+      environment: npm-release
+      run-tests: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to tilelive-mapnik
+
+## Development
+
+```bash
+npm ci
+npm test
+```
+
+## Releasing a new version
+
+Releases are published to npm via GitHub Actions.
+
+### Steps
+
+1. **Bump the version** in `package.json` (follow [semver](https://semver.org))
+2. **Update `CHANGELOG.md`** with a summary of what changed
+3. **Open a PR**, get it reviewed and merged to `master`
+4. **Trigger the release** from the [Actions tab](../../actions/workflows/npm-release.yml):
+   - Select **NPM release** → **Run workflow** → run from `master`
+
+The workflow will publish to npm and create a GitHub release with auto-generated notes.
+
+> **Note:** Only Mapbox maintainers with write access to this repository can trigger the release workflow. External contributors can open and contribute to PRs, but releases are always cut by the owning team.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-mapnik",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./lib/mapnik_backend.js",
   "description": "Mapnik backend for tilelive",
   "url": "http://github.com/mapbox/tilelive-mapnik",
@@ -37,5 +37,8 @@
   },
   "scripts": {
     "test": "mocha -R spec --timeout 10000"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

- **`.github/workflows/npm-release.yml`**: new `workflow_dispatch` workflow that publishes to npm and creates a GitHub release using OIDC Trusted Publishing — no npm tokens required.
- **`CONTRIBUTING.md`**: documents the release process — bump version, update CHANGELOG, merge PR, trigger workflow from Actions tab.
- **`package.json`**: patch version bump and `publishConfig: { access: "public" }` for the scoped package.

## Prerequisites before merging

The workflow uses an `npm-release` GitHub Environment as a release gate. Before merging, create it in this repo:

1. Go to **Settings → Environments → New environment**, name it `npm-release`
2. Under **Deployment branches**, restrict to the default branch (`master`)
3. Under **Required reviewers**, add your team (or `mapbox/team-mapbox` to allow any Mapbox employee to approve)

Without this environment, the workflow will fail when triggered.

**Trigger:** once merged, run from the [Actions tab](../../actions/workflows/npm-release.yml) → NPM release → Run workflow → approve the environment gate.

Ticket: https://mapbox.atlassian.net/browse/CLOUDPLAT-3162
